### PR TITLE
feat(container): Add BoxItem, FlexBox, StackBox examples

### DIFF
--- a/react-examples/stories/Containers/BoxItem.stories.js
+++ b/react-examples/stories/Containers/BoxItem.stories.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import TwixtBoxItem from '../../../react/src/Containers/BoxItem';
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+export default {
+  title: 'Containers/TwixtBoxItem',
+  component: TwixtBoxItem,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+  },
+  args: {
+    type: ['block', 'inline'],
+  },
+};
+
+export const BlockBoxItem = {
+  args: {
+    type: 'block',
+    children: (<>block content</>)
+  },
+};
+
+export const InlineBoxItem = {
+  args: {
+    type: 'inline',
+    children: (<>Inline content</>)
+  },
+};

--- a/react-examples/stories/Containers/FlexBox.stories.js
+++ b/react-examples/stories/Containers/FlexBox.stories.js
@@ -1,0 +1,243 @@
+import React from 'react';
+import TwixtButton from '../../../react/src/CallsToAction/Button';
+import TwixtBoxItem from '../../../react/src/Containers/BoxItem';
+import TwixtFlexBox from '../../../react/src/Containers/FlexBox';
+
+export default {
+  title: 'Containers/TwixtFlexBox',
+  component: TwixtFlexBox,
+  subcomponents: { TwixtBoxItem, TwixtButton },
+  tags: ['autodocs'],
+  argTypes: {
+    direction: {
+      control: { type: 'select' },
+      options: ['row', 'column'],
+      defaultValue: 'row',
+    },
+    grow: { control: 'boolean', defaultValue: false },
+    shrink: { control: 'boolean', defaultValue: false },
+    wrap: { control: 'boolean', defaultValue: false },
+    rowGap: { control: 'text', defaultValue: '0' },
+    columnGap: { control: 'text', defaultValue: '0' },
+    alignItems: {
+      control: { type: 'select' },
+      options: ['start', 'center', 'end', 'stretch'],
+      defaultValue: 'stretch',
+    },
+    justifyContent: {
+      control: { type: 'select' },
+      options: ['start', 'center', 'end', 'between', 'around', 'evenly'],
+      defaultValue: 'start',
+    },
+    alignSelf: {
+      control: { type: 'select' },
+      options: ['auto', 'start', 'center', 'end', 'stretch'],
+      defaultValue: 'auto',
+    },
+    overwriteClass: { control: 'text', defaultValue: '' },
+  },
+};
+
+const Template = (args) => (
+  <TwixtFlexBox overwriteClass="bg-gray-100 p-4" {...args}>
+    {args.children != null ? args.children : (
+      <>
+        <TwixtButton label="Item 1" />
+        <TwixtButton label="Item 2" />
+        <TwixtButton label="Item 3" />
+      </>
+    )}
+  </TwixtFlexBox>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  direction: 'row',
+  grow: false,
+  shrink: false,
+  wrap: false,
+  rowGap: '2',
+  columnGap: '2',
+  alignItems: 'stretch',
+  justifyContent: 'start',
+  alignSelf: 'auto',
+  overwriteClass: '',
+};
+
+export const RowDirection = Template.bind({});
+RowDirection.args = {
+  direction: 'row',
+  wrap: true,
+  rowGap: '4',
+  children: (
+    <>
+      <TwixtBoxItem key="0">Row Item 1</TwixtBoxItem>
+      <TwixtBoxItem key="1">Row Item 2</TwixtBoxItem>
+      <TwixtBoxItem key="2">Row Item 3</TwixtBoxItem>
+    </>
+  )
+};
+
+export const ColumnDirection = Template.bind({});
+ColumnDirection.args = {
+  direction: 'column',
+  wrap: false,
+  columnGap: '4',
+  alignItems: 'center',
+  justifyContent: 'center',
+  children: (
+    <>
+      <TwixtBoxItem key="0">Column Item 1</TwixtBoxItem>
+      <TwixtBoxItem key="1">Column Item 2</TwixtBoxItem>
+      <TwixtBoxItem key="2">Column Item 3</TwixtBoxItem>
+    </>
+  )
+};
+
+export const GrowExample = Template.bind({});
+GrowExample.args = {
+  direction: 'row',
+  grow: true, // This will allow the items to grow
+  alignItems: 'center',
+  justifyContent: 'start',
+  className: 'bg-gray-100 p-4 h-500', // Set a container height of 500px for visibility
+  children: (
+    <>
+      <TwixtBoxItem key="0" overwriteClass="bg-blue-500 p-2 text-white flex-grow">Item 1 (Grow)</TwixtBoxItem>
+      <TwixtBoxItem key="1" overwriteClass="bg-green-500 p-2 text-white">Item 2</TwixtBoxItem>
+      <TwixtBoxItem key="2" overwriteClass="bg-red-500 p-2 text-white">Item 3</TwixtBoxItem>
+    </>
+  ),
+};
+
+export const ShrinkExample = Template.bind({});
+ShrinkExample.args = {
+  direction: 'row',
+  shrink: true, // This will allow the items to shrink
+  alignItems: 'center',
+  justifyContent: 'start',
+  className: 'bg-gray-100 p-4 h-500 w-full', // Set a full-width and height container
+  children: (
+    <>
+      <TwixtBoxItem key="0" overwriteClass="bg-blue-500 p-2 text-white flex-shrink">Item 1 (Shrink)</TwixtBoxItem>
+      <TwixtBoxItem key="1" overwriteClass="bg-green-500 p-2 text-white">Item 2</TwixtBoxItem>
+      <TwixtBoxItem key="2" overwriteClass="bg-red-500 p-2 text-white">Item 3</TwixtBoxItem>
+    </>
+  ),
+};
+
+export const CenterAligned = Template.bind({});
+CenterAligned.args = {
+  direction: 'row',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+export const WrapToNextLine = Template.bind({});
+WrapToNextLine.args = {
+  direction: 'row',
+  wrap: true,
+  rowGap: '4',
+  columnGap: '4',
+  overwriteClass: 'bg-red-100 h-80 p-5',
+  children: (
+    <>
+      <TwixtBoxItem key="0" overwriteClass="w-1/4 p-4 bg-gray-100 text-gray-800">Item 1</TwixtBoxItem>
+      <TwixtBoxItem key="1" overwriteClass="w-1/4 p-4 bg-gray-100 text-gray-800">Item 2</TwixtBoxItem>
+      <TwixtBoxItem key="2" overwriteClass="w-1/4 p-4 bg-gray-100 text-gray-800">Item 3</TwixtBoxItem>
+      <TwixtBoxItem key="3" overwriteClass="w-1/4 p-4 bg-gray-100 text-gray-800">Item 4</TwixtBoxItem>
+      <TwixtBoxItem key="4" overwriteClass="w-1/4 p-4 bg-gray-100 text-gray-800">Item 5</TwixtBoxItem>
+      <TwixtBoxItem key="5" overwriteClass="w-1/4 p-4 bg-gray-100 text-gray-800">Item 6</TwixtBoxItem>
+    </>
+  ),
+};
+
+export const AlignToMiddle = Template.bind({});
+AlignToMiddle.args = {
+  direction: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  rowGap: '2',
+  overwriteClass: 'bg-red-100 h-80 p-5',
+  children: (
+    <>
+      <TwixtBoxItem key="0">Item 1</TwixtBoxItem>
+      <TwixtBoxItem key="1">Item 2</TwixtBoxItem>
+      <TwixtBoxItem key="2">Item 3</TwixtBoxItem>
+    </>
+  ),
+};
+
+export const AlignToTop = Template.bind({});
+AlignToTop.args = {
+  direction: 'column',
+  alignItems: 'start',
+  justifyContent: 'start',
+  rowGap: '2',
+  overwriteClass: 'bg-red-100 h-80 p-5',
+  children: (
+    <>
+      <TwixtBoxItem key="0" overwriteClass="bg-green-500 p-2 text-white">Item 1</TwixtBoxItem>
+      <TwixtBoxItem key="1" overwriteClass="bg-green-500 p-2 text-white">Item 2</TwixtBoxItem>
+      <TwixtBoxItem key="2" overwriteClass="bg-green-500 p-2 text-white">Item 3</TwixtBoxItem>
+    </>
+  ),
+};
+
+export const AlignToBottom = Template.bind({});
+AlignToBottom.args = {
+  direction: 'column',
+  alignItems: 'end',
+  justifyContent: 'end',
+  rowGap: '2',
+  overwriteClass: 'bg-red-100 h-80 p-5',
+  children: (
+    <>
+      <TwixtBoxItem key="0">Item 1</TwixtBoxItem>
+      <TwixtBoxItem key="1">Item 2</TwixtBoxItem>
+      <TwixtBoxItem key="2">Item 3</TwixtBoxItem>
+    </>
+  ),
+};
+
+export const AlignToLeft = Template.bind({});
+AlignToLeft.args = {
+  direction: 'row',
+  justifyContent: 'start',
+  columnGap: '4',
+  children: (
+    <>
+      <TwixtBoxItem key="0">Item 1</TwixtBoxItem>
+      <TwixtBoxItem key="1">Item 2</TwixtBoxItem>
+      <TwixtBoxItem key="2">Item 3</TwixtBoxItem>
+    </>
+  ),
+};
+
+export const AlignToCenter = Template.bind({});
+AlignToCenter.args = {
+  direction: 'row',
+  justifyContent: 'center',
+  columnGap: '4',
+  children: (
+    <>
+      <TwixtBoxItem key="0">Item 1</TwixtBoxItem>
+      <TwixtBoxItem key="1">Item 2</TwixtBoxItem>
+      <TwixtBoxItem key="2">Item 3</TwixtBoxItem>
+    </>
+  ),
+};
+
+export const AlignToRight = Template.bind({});
+AlignToRight.args = {
+  direction: 'row',
+  justifyContent: 'end',
+  columnGap: '4',
+  children: (
+    <>
+      <TwixtBoxItem key="0">Item 1</TwixtBoxItem>
+      <TwixtBoxItem key="1">Item 2</TwixtBoxItem>
+      <TwixtBoxItem key="2">Item 3</TwixtBoxItem>
+    </>
+  ),
+};

--- a/react-examples/stories/Containers/StackBox.stories.js
+++ b/react-examples/stories/Containers/StackBox.stories.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import TwixtBoxItem from '../../../react/src/Containers/BoxItem';
+import StackBox from '../../../react/src/Containers/StackBox';
+
+export default {
+  title: 'Containers/StackBox',
+  component: StackBox,
+  subcomponents: { TwixtBoxItem },
+  argTypes: {
+    direction: {
+      control: { type: 'select' },
+      options: ['horizontal', 'vertical'],
+      defaultValue: 'horizontal',
+    },
+    className: { control: 'text', defaultValue: '' },
+  },
+};
+
+const Template = (args) => (
+  <StackBox {...args} className="bg-gray-100 p-4">
+    {args.children}
+  </StackBox>
+);
+
+export const HorizontalStack = Template.bind({});
+HorizontalStack.args = {
+  direction: 'horizontal',
+  className: 'gap-4',
+  children: (
+    <>
+      <TwixtBoxItem key="0" overwriteClass="bg-blue-500 p-2 text-white">Column 1</TwixtBoxItem>
+      <TwixtBoxItem key="1" overwriteClass="bg-green-500 p-2 text-white">Column 2</TwixtBoxItem>
+      <TwixtBoxItem key="2" overwriteClass="bg-red-500 p-2 text-white">Column 3</TwixtBoxItem>
+    </>
+  ),
+};
+
+export const VerticalStack = Template.bind({});
+VerticalStack.args = {
+  direction: 'vertical',
+  className: 'gap-4',
+  children: (
+    <>
+      <TwixtBoxItem key="0" overwriteClass="bg-blue-500 p-2 text-white">Row 1</TwixtBoxItem>
+      <TwixtBoxItem key="1" overwriteClass="bg-green-500 p-2 text-white">Row 2</TwixtBoxItem>
+      <TwixtBoxItem key="2" overwriteClass="bg-red-500 p-2 text-white">Row 3</TwixtBoxItem>
+    </>
+  ),
+};
+
+export const NestedStack = Template.bind({});
+NestedStack.args = {
+  direction: 'horizontal',
+  className: 'gap-4',
+  children: (
+    <>
+      <TwixtBoxItem key="0" overwriteClass="bg-blue-500 p-2 text-white">Column 1</TwixtBoxItem>
+      <StackBox direction="vertical" className="bg-green-500 p-2 text-white gap-2">
+        <TwixtBoxItem key="0" overwriteClass="bg-yellow-500 p-2 text-white">Row 1 in Column 2</TwixtBoxItem>
+        <TwixtBoxItem key="1" overwriteClass="bg-orange-500 p-2 text-white">Row 2 in Column 2</TwixtBoxItem>
+        <TwixtBoxItem key="2" overwriteClass="bg-pink-500 p-2 text-white">Row 3 in Column 2</TwixtBoxItem>
+      </StackBox>
+      <TwixtBoxItem key="2" overwriteClass="bg-red-500 p-2 text-white">Column 3</TwixtBoxItem>
+    </>
+  ),
+};

--- a/react/src/Containers/BoxItem/BoxItem.js
+++ b/react/src/Containers/BoxItem/BoxItem.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+function BoxItem({ type = 'block', children, overwriteClass = '' }) {
+  if (type == 'block') {
+    return <div className={overwriteClass}>{children}</div>;
+  } else if (type == 'inline') {
+    return <span className={overwriteClass}>{children}</span>;
+  }
+
+  return null;
+}
+
+export default BoxItem;

--- a/react/src/Containers/BoxItem/index.js
+++ b/react/src/Containers/BoxItem/index.js
@@ -1,0 +1,2 @@
+export { default } from './BoxItem';
+

--- a/react/src/Containers/Flexbox/Flexbox.js
+++ b/react/src/Containers/Flexbox/Flexbox.js
@@ -1,7 +1,33 @@
-import React from 'react'
+import React from 'react';
 
-function Flexbox() {
-  return <>Flexbox goes here.</>
+function FlexBox({
+  direction = 'row',
+  grow = false,
+  shrink = false,
+  wrap = false,
+  rowGap = '0',
+  columnGap = '0',
+  alignItems = 'stretch',
+  justifyContent = 'start',
+  alignSelf = 'auto',
+  children,
+  overwriteClass = '',
+}) {
+  const flexClasses = `
+    flex
+    ${direction === 'column' ? 'flex-col' : 'flex-row'}
+    ${grow ? 'flex-grow' : ''}
+    ${shrink ? 'flex-shrink' : ''}
+    ${wrap ? 'flex-wrap' : ''}
+    ${rowGap !== '0' ? `gap-y-${rowGap}` : ''}
+    ${columnGap !== '0' ? `gap-x-${columnGap}` : ''}
+    ${alignItems ? `items-${alignItems}` : ''}
+    ${justifyContent ? `justify-${justifyContent}` : ''}
+    ${alignSelf ? `self-${alignSelf}` : ''}
+    ${overwriteClass}
+  `.trim().replace(/\s+/g, ' ');
+
+  return <div className={flexClasses}>{children}</div>;
 }
 
-export default Flexbox
+export default FlexBox;

--- a/react/src/Containers/Flexbox/index.js
+++ b/react/src/Containers/Flexbox/index.js
@@ -1,1 +1,1 @@
-export { default } from './Flexbox'
+export { default } from './FlexBox';

--- a/react/src/Containers/StackBox/StackBox.js
+++ b/react/src/Containers/StackBox/StackBox.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+function StackBox({ direction = 'horizontal', children, overwriteClass = '' }) {
+  const stackClasses = direction === 'horizontal' ? 'flex' : 'flex flex-col';
+  return <div className={`${stackClasses} ${overwriteClass}`}>{children}</div>;
+}
+
+export default StackBox;

--- a/react/src/Containers/StackBox/index.js
+++ b/react/src/Containers/StackBox/index.js
@@ -1,0 +1,1 @@
+export { default } from './StackBox';

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -38,3 +38,12 @@ export { default as TwixtLink } from './CallsToAction/Link';
 // Group - Communications
 export { default as TwixtToolTip } from './Communications/ToolTip';
 
+// Group - List
+export { default as TwixtCollapsibleList } from './List/CollapsibleList';
+export { default as TwixtList } from './List/List';
+
+// Group - Containers
+export { default as TwixtBoxItem } from './Containers/BoxItem';
+export { default as TwixtFlexBox } from './Containers/FlexBox';
+export { default as TwixtStackBox } from './Containers/StackBox';
+


### PR DESCRIPTION
### Current Problem

There is no flexbox option

### After Implementation

#### Box Item
![image](https://github.com/user-attachments/assets/3b251fa4-2173-4128-87d6-5023db5f1901)

#### Flex Box Item
![image](https://github.com/user-attachments/assets/8aaea5f3-3402-4dc4-84d4-84e663aa3f4e)

#### Stack Box Item

![image](https://github.com/user-attachments/assets/c2e3fc5b-15c5-4908-afda-a997e90690f5)

### Steps to Reproduce this issue

-