### PR TITLE
feat(communication/hover-card): add basic 4 examples with position

### DIFF
--- a/react/src/Communications/HoverCard/HoverCard.js
+++ b/react/src/Communications/HoverCard/HoverCard.js
@@ -1,7 +1,94 @@
-import React from 'react'
+import TwixtLink from '../../CallsToAction/Link';
+import TwixtIcon from '../../Icon';
+import TwixtStackBox from '../../Containers/StackBox';
+import TwixtBoxItem from '../../Containers/BoxItem';
 
-function HoverCard() {
-  return <>HoverCard goes here.</>
-}
+import { format } from 'date-fns'; 
+import React, { useState, useRef } from 'react';
 
-export default HoverCard
+const HoverCard = ({ children, cardDetails, position = 'right' }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const timeoutRef = useRef(null);
+
+  const whenFormatedDate = cardDetails?.when ? format(new Date(cardDetails?.when), cardDetails?.whenFormat || 'PPP') : 'No date available';
+
+  // Determine the classes based on the position prop
+  const positionClasses = {
+    top: 'bottom-full mb-3',
+    bottom: 'top-full mt-3',
+    left: 'right-full mr-3',
+    right: 'left-full ml-3',
+  };
+
+  const handleMouseEnter = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(true);
+  };
+
+  const handleMouseLeave = () => {
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(false);
+    }, 300); // Adjust this delay as needed (in milliseconds)
+  };
+
+  return (
+    <div
+      className="relative group inline-block"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+
+      {/* Popover Content */}
+      <div
+        className={`absolute ${positionClasses[position] || positionClasses.right} w-64 p-4 bg-white border border-gray-100 text-start rounded-xl shadow-md transition-opacity duration-300 z-10 ${
+          isVisible ? 'opacity-100 visible' : 'opacity-0 invisible'
+        }`}
+      >
+        <TwixtStackBox direction="vertical">
+          <TwixtLink leftIcon={<TwixtIcon type="settings" variant="outline" />} label={cardDetails.id} link={cardDetails.idLink} overwriteClass="text-sm gap-1 mb-1" />
+          <TwixtLink label={cardDetails.mainTitle} link={cardDetails.mainLink} overwriteClass="text-base" />
+          {cardDetails?.whenLabel != null && <TwixtBoxItem overwriteClass="text-xs text-gray-300 mb-2">
+            {cardDetails?.whenLabel} {whenFormatedDate}
+          </TwixtBoxItem>}
+        </TwixtStackBox>
+        <div className="flex items-center gap-x-3 mb-4">
+          {cardDetails.avatar != null && <img
+            className="inline-block w-10 h-10 rounded-full"
+            src={cardDetails.avatar}
+            alt="Avatar"
+          />}
+          <div className="grow">
+            <h4 className="font-semibold text-gray-800">{cardDetails.name}</h4>
+            <span className="text-xs bg-gray-800 text-white py-0.5 px-1.5 rounded-md">
+              {cardDetails.role}
+            </span>
+            <p className="text-sm text-gray-500">{cardDetails.title}</p>
+          </div>
+        </div>
+
+        {/* User Details */}
+        <ul className="space-y-2">
+          {cardDetails.details.map((detail, index) => (
+            <li key={index} className="flex items-center gap-x-2 text-sm text-gray-800">
+              {detail.icon}
+              {detail.content}
+            </li>
+          ))}
+        </ul>
+
+        {/* Footer */}
+        <div className="mt-4 flex justify-between items-center">
+          <TwixtLink label={cardDetails.viewLabel} link={cardDetails.mainLink} overwriteClass="text-xs text-gray-500 hover:text-blue-600" />
+          {/* <button className="py-1 px-3 bg-blue-600 text-white text-sm rounded-full hover:bg-blue-700">
+            Follow
+          </button> */}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HoverCard;

--- a/react/src/Icon.js
+++ b/react/src/Icon.js
@@ -44,9 +44,18 @@ import {
   FaShareAlt,
   FaFileAlt,
   FaLockOpen,
+  FaRegUser,
+  FaUserAltSlash,
+  FaUserGraduate,
+  FaUserGroup,
+  FaBuilding,
+  FaRegBuilding,
+  FaMobileAlt,
 } from 'react-icons/fa';
 
-import { CiHeadphones } from "react-icons/ci";
+import { CiMail, CiHeadphones } from "react-icons/ci";
+
+import { IoSettings, IoSettingsOutline } from "react-icons/io5";
 
 import {
   PiSpeakerSimpleHighFill, PiSpeakerSimpleHighLight,
@@ -88,6 +97,14 @@ const iconTypes = {
   file: {filled: FaFile, outline: FaFileAlt },
   lock: {filled: FaLock, outline: FaLockOpen },
   share: {filled: FaShareAlt, outline: null },
+  user: {filled: FaUser, outline: FaRegUser },
+  userSlashed: {filled: FaUserAltSlash, outline: null },
+  userGraduate: {filled: FaUserGraduate, outline: null },
+  userGroup: {filled: FaUserGroup, outline: null },
+  office: {filled: FaBuilding, outline: FaRegBuilding },
+  mobile: {filled: FaMobileAlt, outline: null },
+  mail: {filled: null, outline: CiMail },
+  settings: {filled: IoSettings, outline: IoSettingsOutline },
 };
 
 export default function TwixtIcon({ type = 'notification', variant = 'filled', size = 12, color = 'black' }) {


### PR DESCRIPTION
### Current Problem

There is no option for hover card details

### After Implementation

![image](https://github.com/user-attachments/assets/6ba0fd0d-a475-4304-a48a-8ec78628538a)


### Steps to Reproduce this issue

-