### PR TITLE
feat(communication/spinner): add size variation and page level spinner

### DIFF
--- a/react-examples/stories/CallsToAction/ButtonGroup.stories.js
+++ b/react-examples/stories/CallsToAction/ButtonGroup.stories.js
@@ -2,7 +2,6 @@ import React from 'react';
 import TwixtButtonGroup from '../../../react/src/CallsToAction/ButtonGroup';
 import TwixtButton from '../../../react/src/CallsToAction/Button';
 import TwixtIcon from '../../../react/src/Icon';
-import { background } from '@storybook/theming';
 
 export default {
   title: 'Call To Action/TwixtButtonGroup',

--- a/react-examples/stories/CallsToAction/FloatingButton.stories.js
+++ b/react-examples/stories/CallsToAction/FloatingButton.stories.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import FloatingButton from '../../../react/src/CallsToAction/FloatingButton';
+import TwixtFloatingButton from '../../../react/src/CallsToAction/FloatingButton';
 import TwixtButton from '../../../react/src/CallsToAction/Button';
 
 export default {
-  title: 'Call To Action/FloatingButton',
-  component: FloatingButton,
+  title: 'Call To Action/TwixtFloatingButton',
+  component: TwixtFloatingButton,
   parameters: {
     layout: 'centered',
   },
@@ -27,7 +27,7 @@ export default {
   },
 };
 
-const Template = (args) => <FloatingButton {...args} />;
+const Template = (args) => <TwixtFloatingButton {...args} />;
 
 export const DefaultBottomRight = Template.bind({});
 DefaultBottomRight.args = {

--- a/react-examples/stories/Communications/HoverCard.stories.js
+++ b/react-examples/stories/Communications/HoverCard.stories.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import TwixtHoverCard from '../../../react/src/Communications/HoverCard';
+import TwixtIcon from '../../../react/src/Icon';
+import { format } from 'date-fns';
+
+export default {
+  title: 'Communications/TwixtHoverCard',
+  component: TwixtHoverCard,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+const Template = (args) => <TwixtHoverCard {...args} />;
+
+export const DefaultInRight = Template.bind({});
+DefaultInRight.args = {
+  cardDetails: {
+    title: 'CEO',
+    link: 'https://www.linkedin.com/in/sundarpichai/',
+    avatar: 'https://media.licdn.com/dms/image/v2/D4E03AQFrmDuWUxQoMg/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1715645354619?e=1730332800&v=beta&t=anVTKtG8AuE6DqTIdryd8lOZhdoAEqQgxcVwP5FmtdI',
+    name: 'Sundar Pichai',
+    role: 'CEO',
+    viewLabel: 'View Profile',
+    details: [
+      {
+        icon: <TwixtIcon type="office" variant="outline" />,
+        content: 'Google Inc',
+      },
+      {
+        icon: <TwixtIcon type="mobile" variant="filled" />,
+        content: '(555) 123-4567',
+      },
+      {
+        icon: <TwixtIcon type="mail" variant="outline" />,
+        content: 'Sundar.Pichai@example.com',
+      },
+    ],
+  },
+  children: (
+    <a href="#">Hover me default link</a>
+  ),
+};
+
+export const WithIDLinkedInTop  = Template.bind({});
+WithIDLinkedInTop.args = {
+  ...DefaultInRight.args,
+  position: 'top',
+  children: (
+    <button className="ml-auto py-1 px-3 bg-green-500 text-white text-sm rounded">
+      Contact
+    </button>
+  ),
+};
+WithIDLinkedInTop.args.cardDetails = {
+  ...DefaultInRight.args.cardDetails,
+  id: 'ProfileID1231',
+  idLink: 'https://www.linkedin.com/in/sundarpichai/',
+}
+
+export const WithMainTitleInBottom  = Template.bind({});
+WithMainTitleInBottom.args = {
+  ...DefaultInRight.args,
+  position: 'bottom',
+  children: (
+    <a href="#" className="ml-auto text-sm text-green-500 hover:underline">
+      View Details
+    </a>
+  ),
+};
+WithMainTitleInBottom.args.cardDetails = {
+  ...DefaultInRight.args.cardDetails,
+  id: 'ProfileID1231',
+  idLink: 'https://www.linkedin.com/in/sundarpichai/',
+  mainTitle: 'Google CEO (Main Title)',
+  mainLink: 'https://www.linkedin.com/in/sundarpichai/',
+}
+
+export const WithDateLabelWithLeft  = Template.bind({});
+WithDateLabelWithLeft.args = {
+  ...DefaultInRight.args,
+  position: 'left',
+  children: (
+    <a href="#" className="ml-auto text-sm text-green-500 hover:underline">
+      View Details
+    </a>
+  ),
+};
+WithDateLabelWithLeft.args.cardDetails = {
+  ...DefaultInRight.args.cardDetails,
+  id: 'ProfileID1231',
+  idLink: 'https://www.linkedin.com/in/sundarpichai/',
+  mainTitle: 'Google CEO (Main Title)',
+  mainLink: 'https://www.linkedin.com/in/sundarpichai/',
+  when: '2024-08-27T00:00:00Z',
+  whenFormat: 'MMM dd, yyyy',
+  whenLabel: 'Commenced on ',
+}

--- a/react-examples/stories/Communications/Spinner.stories.js
+++ b/react-examples/stories/Communications/Spinner.stories.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import TwixtSpinner from '../../../react/src/Communications/Spinner';
+
+export default {
+  title: 'Communications/TwixtSpinner',
+  component: TwixtSpinner,
+  argTypes: {
+    size: {
+      control: {
+        type: 'select',
+        options: ['sm', 'md', 'lg', 'xl'],
+      },
+      defaultValue: 'md',
+    },
+    fullPage: {
+      control: 'boolean',
+      defaultValue: false,
+    },
+    label: {
+      control: 'text',
+      defaultValue: 'Loading...',
+    },
+  },
+};
+
+const Template = (args) => <TwixtSpinner {...args} />;
+
+export const SmallBlock = Template.bind({});
+SmallBlock.args = {
+  size: 'sm',
+  label: 'Loading small...',
+};
+
+export const MediumBlock = Template.bind({});
+MediumBlock.args = {
+  size: 'md',
+  label: 'Loading medium...',
+};
+
+export const LargeBlock = Template.bind({});
+LargeBlock.args = {
+  size: 'lg',
+  label: 'Loading large...',
+};
+
+export const FullPage = Template.bind({});
+FullPage.args = {
+  size: 'xl',
+  fullPage: true,
+  label: 'Loading full page...',
+};

--- a/react/src/Communications/Spinner/Spinner.js
+++ b/react/src/Communications/Spinner/Spinner.js
@@ -1,26 +1,36 @@
 import React from 'react';
-import TwixtSpinner from '../../Communications/Spinner';
 
-export default function TwixtButton({
-  background = 'bg-indigo-500',
-  color = 'text-white',
-  children,
-  leftIcon = null,
-  rightIcon = null,
-  label,
-  hideLabel = false,
-  disabled = false,
-  showSpinner = false,
-  onClick,
-  overwriteClass,
-}) {
-  const buttonClasses = overwriteClass || 'px-4 py-2 rounded-md';
+const Spinner = ({
+  label = '',
+  size = 'md',
+  fullPage = false,
+  overwriteClass = '',
+  bgColor = 'bg-gray-200 bg-opacity-70',
+}) => {
+  // Define size classes
+  const sizeClasses = {
+    sm: 'w-4 h-4 text-xs',  // Smaller spinner and smaller text
+    md: 'w-8 h-8 text-sm',  // Medium spinner and medium text
+    lg: 'w-16 h-16 text-base',  // Larger spinner and larger text
+    xl: 'w-24 h-24 text-lg',  // Extra large spinner and larger text
+  };
 
-  const spinnerIcon = (
-    <div role="status">
+  // Choose size based on prop, default to medium size
+  const spinnerSize = sizeClasses[size] || sizeClasses.md;
+
+  // Conditional full-page styling
+  const fullPageClasses = fullPage
+    ? `fixed inset-0 flex flex-col items-center justify-center ${bgColor} z-50`
+    : '';
+
+  return (
+    <div
+      role="status"
+      className={`${fullPageClasses} ${overwriteClass}`}
+    >
       <svg
         aria-hidden="true"
-        className="inline w-4 h-4 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600"
+        className={`inline ${spinnerSize.split(' ')[0]} text-gray-200 animate-spin fill-blue-600`}
         viewBox="0 0 100 101"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -34,34 +44,9 @@ export default function TwixtButton({
           fill="currentFill"
         />
       </svg>
-      <span className="sr-only">Loading...</span>
+      {label && <span className={`ml-2 mt-2 ${spinnerSize.split(' ')[1]}`}>{label}</span>}
     </div>
   );
+};
 
-  return (
-    <button
-      onClick={onClick}
-      className={`flex items-center justify-center space-x-2 ${background} ${color} ${buttonClasses}`}
-      disabled={showSpinner || disabled}
-    >
-      {children ? (
-        children
-      ) : (
-        <>
-          {leftIcon && (
-            <span>{leftIcon}</span>
-          )}
-          {!hideLabel && (
-            <span>{label}</span>
-          )}
-          {showSpinner && (
-            <TwixtSpinner size="sm" overwriteClass="flex" />
-          )}
-          {rightIcon && (
-            <span>{rightIcon}</span>
-          )}
-        </>
-      )}
-    </button>
-  );
-}
+export default Spinner;

--- a/react/src/Communications/Spinner/index.js
+++ b/react/src/Communications/Spinner/index.js
@@ -1,0 +1,1 @@
+export { default } from './Spinner'


### PR DESCRIPTION
### Current Problem

There is no page level spinner and size option

### After Implementation

![image](https://github.com/user-attachments/assets/3f3fc4bb-bf01-45ef-b0a1-50acf3422f62)


### Steps to Reproduce this issue

-