### PR TITLE
fix(container/popup): enhanced along with onClose and closeIcon

### DIFF
--- a/react/src/Containers/Popover/Popover.js
+++ b/react/src/Containers/Popover/Popover.js
@@ -1,4 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
+import TwixtIcon from '../../Icon';
+import TwixtButton from '../../CallsToAction/Button';
 
 const Popover = ({
   id,
@@ -9,6 +11,8 @@ const Popover = ({
   children,
   scrollable = false,
   hideOnBlur = true,
+  closeIcon = true,
+  onClose = () => {},
   overwriteContentClass = ''
 }) => {
   const [isOpen, setIsOpen] = useState(show);
@@ -54,10 +58,19 @@ const Popover = ({
         <div
           ref={popoverRef}
           role="tooltip"
-          className={`absolute z-10 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-100 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800 ${positionClass(position)} w-auto min-w-[200px] ${scrollable ? 'max-h-[300px]' : 'max-h-[none]'} ${scrollable ? 'overflow-y-auto' : ''}`}
+          className={`absolute z-10 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-100 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800 ${positionClass(position)} w-auto min-w-[200px] `}
         >
-          <div className="px-3 py-2 bg-gray-100 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
-            <h3 className="font-semibold text-gray-900 dark:text-white">{title}</h3>
+          <div className="flex items-center justify-between px-3 py-2 bg-gray-100 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+            <h3 className="font-semibold text-gray-900 dark:text-white flex-1">{title}</h3>
+            {closeIcon && (<TwixtButton
+              hideLabel
+              leftIcon={<TwixtIcon type="close" color="black" size={18} variant="filled" />}
+              overwriteClass="bg-transparent text-gray-400 hover:text-gray-600"
+              onClick={() => {
+                setIsOpen(false);
+                onClose();
+              }}
+            />)}
           </div>
           <div className={`${scrollable ? 'overflow-y-auto max-h-[300px]' : ''} ${overwriteContentClass ? overwriteContentClass : 'px-3 py-2'}`}>
             {content}

--- a/react/src/Inputs/DateOrTimeInput/DatePicker.js
+++ b/react/src/Inputs/DateOrTimeInput/DatePicker.js
@@ -91,7 +91,7 @@ const DatePicker = ({
 
   return (
     <TwixtPopover
-      overwriteContentClass="p-0"
+      overwriteContentClass="min-w-[250px] p-0"
       title={popoverTitle}
       hideOnBlur={false}
       content={

--- a/react/src/Inputs/DateOrTimeInput/TimePicker.js
+++ b/react/src/Inputs/DateOrTimeInput/TimePicker.js
@@ -8,7 +8,6 @@ const TimePicker = ({ label = '', popoverTitle = '', selectionType = 'single', o
   const [endTimeValue, setEndTimeValue] = useState('');
   const [selectedTime, setSelectedTime] = useState(null);
   const [selectedTimeRange, setSelectedTimeRange] = useState({ start: null, end: null });
-  const [currentTime, setCurrentTime] = useState(new Date());
 
   useEffect(() => {
     const now = new Date();
@@ -80,9 +79,10 @@ const TimePicker = ({ label = '', popoverTitle = '', selectionType = 'single', o
 
   return (
     <TwixtPopover
-      overwriteContentClass="p-0"
+      overwriteContentClass="min-w-[300px] px-1"
       title={popoverTitle}
       hideOnBlur={false}
+      scrollable={true}
       content={(
         <div className="p-4">
           <div className="grid grid-cols-4 gap-2">


### PR DESCRIPTION
### Current Problem

> There is no close button and date timepicker is broken and not good to select

### After Implementation

TwixtPopup
1. added additional closeIcon, onClose Props,

TwixtDatePicker
2. Updated the Popup  Width to see all the dates

TwixtTimePicker
3. Updated the Popup width to see all the times

<img width="624" alt="image" src="https://github.com/user-attachments/assets/006ae30f-2deb-4686-9e12-719c8149794f">

<img width="629" alt="image" src="https://github.com/user-attachments/assets/6a378736-764d-40da-934f-c71289e2fa83">

<img width="650" alt="image" src="https://github.com/user-attachments/assets/2429b32e-033f-4da6-b9f3-eb89b59716b8">

<img width="636" alt="image" src="https://github.com/user-attachments/assets/bd93b525-310b-4fbe-89e7-9e256286120c">


### Steps to Reproduce this issue

-