### PR TITLE
feat(navigation/tabs): add tabs basic implementation

### DIFF
--- a/react-examples/stories/Communications/Badge.stories.js
+++ b/react-examples/stories/Communications/Badge.stories.js
@@ -5,6 +5,7 @@ import TwixtIcon from '../../../react/src/Icon';
 export default {
   title: 'Communications/TwixtBadge',
   component: TwixtBadge,
+  tags: ['autodocs'],
   argTypes: {
     value: { control: 'text' },
     status: { 

--- a/react-examples/stories/Communications/Notice.stories.js
+++ b/react-examples/stories/Communications/Notice.stories.js
@@ -7,6 +7,7 @@ import TwixtIcon from '../../../react/src/Icon';
 export default {
   title: 'Communications/TwixtNotice',
   component: TwixtNotice,
+  tags: ['autodocs'],
   argTypes: {
     title: { control: 'text' },
     overwriteClass: { control: 'text' },

--- a/react-examples/stories/Communications/Spinner.stories.js
+++ b/react-examples/stories/Communications/Spinner.stories.js
@@ -4,6 +4,7 @@ import TwixtSpinner from '../../../react/src/Communications/Spinner';
 export default {
   title: 'Communications/TwixtSpinner',
   component: TwixtSpinner,
+  tags: ['autodocs'],
   argTypes: {
     size: {
       control: {

--- a/react-examples/stories/Communications/StatusDot.stories.js
+++ b/react-examples/stories/Communications/StatusDot.stories.js
@@ -3,6 +3,7 @@ import StatusDot from '../../../react/src/Communications/StatusDot';
 export default {
   title: 'Communications/TwixtStatusDot',
   component: StatusDot,
+  tags: ['autodocs'],
   argTypes: {
     status: { 
         options: ['Active', 'DoNotDisturb', 'InMeeting', 'Away'],

--- a/react-examples/stories/Communications/Toast.stories.js
+++ b/react-examples/stories/Communications/Toast.stories.js
@@ -4,6 +4,7 @@ import TwixtToast from '../../../react/src/Communications/Toast';
 export default {
   title: 'Communications/TwixtToast',
   component: TwixtToast,
+  tags: ['autodocs'],
   argTypes: {
     title: { control: 'text', defaultValue: 'Default Title' },
     body: { control: 'text', defaultValue: 'This is a message body.' },

--- a/react-examples/stories/Communications/Tooltip.stories.js
+++ b/react-examples/stories/Communications/Tooltip.stories.js
@@ -3,6 +3,7 @@ import TwixtToolTip from '../../../react/src/Communications/ToolTip';
 export default {
   title: 'Communications/TwixtToolTip',
   component: TwixtToolTip,
+  tags: ['autodocs'],
   parameters: {
     layout: 'centered',
   },

--- a/react-examples/stories/List/List.stories.js
+++ b/react-examples/stories/List/List.stories.js
@@ -11,6 +11,7 @@ export default {
   title: 'List/List',
   component: List,
   subcomponents: { ListItem },
+  tags: ['autodocs'],
   parameters: {
     layout: 'centered',
     docs: {

--- a/react-examples/stories/List/Tabs.stories.js
+++ b/react-examples/stories/List/Tabs.stories.js
@@ -1,0 +1,90 @@
+import React from 'react';
+
+import TwixtTabs from '../../../react/src/Navigation/Tabs';
+import TwixtIcon from '../../../react/src/Icon';
+import TwixtBadge from '../../../react/src/Communications/Badge';
+
+export default {
+  title: 'List/TwixtTabs',
+  component: TwixtTabs,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+  args: {
+  },
+};
+
+// Default Horizontal Tabs
+export const DefaultHorizontal = () => {
+  const items = [
+    { label: 'Tab 1', content: 'This is the content for Tab 1.' },
+    { label: 'Tab 2', content: 'This is the content for Tab 2.' },
+    { label: 'Tab 3', content: 'This is the content for Tab 3.' },
+  ];
+
+  return <TwixtTabs items={items} direction="horizontal" />;
+};
+
+// Vertical Tabs
+export const VerticalTabs = () => {
+  const items = [
+    { label: 'Tab 1', content: 'This is the content for Tab 1.' },
+    { label: 'Tab 2', content: 'This is the content for Tab 2.' },
+    { label: 'Tab 3', content: 'This is the content for Tab 3.' },
+  ];
+
+  return <TwixtTabs items={items} direction="vertical" />;
+};
+
+// Default Active Tab
+export const DefaultActiveTab = () => {
+  const items = [
+    { label: 'Tab 1', content: 'This is the content for Tab 1.' },
+    { label: 'Tab 2', content: 'This is the content for Tab 2.' },
+    { label: 'Tab 3', content: 'This is the content for Tab 3.' },
+  ];
+
+  return <TwixtTabs items={items} direction="horizontal" defaultActiveTab={1} />;
+};
+
+// Tabs with Icons
+export const TabsWithIcons = () => {
+  const items = [
+    {
+      label: 'Inbox',
+      content: 'This is the content for Tab 1.',
+      rightIcon: () => (
+        <TwixtBadge
+          status="active"
+          value="99+"
+        />
+      ),
+    },
+    {
+      label: 'Hub',
+      content: 'This is the content for Tab 2.',
+      leftIcon: () => (
+        <TwixtIcon type="home" variant="outline" size={18} />
+      ),
+    },
+    {
+      label: 'Terminal',
+      content: 'This is the content for Tab 3.',
+      leftIcon: () => (
+        <TwixtIcon type="terminal" variant="filled" size={18} />
+      ),
+    },
+    {
+      label: 'Notifications',
+      content: 'This is the content for Tab 4.',
+      rightIcon: () => (
+        <TwixtIcon type="notification" variant="filled" size={18} />
+      ),
+    },
+  ];
+
+  return <TwixtTabs items={items} direction="horizontal" />;
+};
+

--- a/react/src/CallsToAction/Link/Link.js
+++ b/react/src/CallsToAction/Link/Link.js
@@ -6,6 +6,7 @@ export default function TwixtLink({
   link = '#', 
   onClick,
   overwriteClass = '',
+  appendClass = '',
   label,
   leftIcon, 
   rightIcon, 
@@ -16,10 +17,12 @@ export default function TwixtLink({
     return null;
   }
 
+  const classNames = overwriteClass || `inline-flex items-center gap-2 ${background} ${color} ${appendClass}`;
+
   return (
     <a
       href={link}
-      className={`inline-flex items-center gap-4 ${background} ${color} ${overwriteClass}`}
+      className={classNames}
       onClick={onClick}
       target={target}
     >

--- a/react/src/Icon.js
+++ b/react/src/Icon.js
@@ -59,7 +59,7 @@ import { MdError, MdErrorOutline, MdClear,MdOutlineClear } from 'react-icons/md'
 
 import { CiMail, CiHeadphones } from "react-icons/ci";
 
-import { IoSettings, IoSettingsOutline, IoInformationCircleOutline } from "react-icons/io5";
+import { IoHome, IoHomeOutline, IoSettings, IoSettingsOutline, IoInformationCircleOutline } from "react-icons/io5";
 
 import {
   PiSpeakerSimpleHighFill, PiSpeakerSimpleHighLight,
@@ -69,6 +69,7 @@ import {
 } from "react-icons/pi";
 
 const iconTypes = {
+  home: { filled: IoHome, outline: IoHomeOutline  },
   notification: { filled: FaBell, outline: FaBellSlash },
   terminal: { filled: FaTerminal, outline: FaTerminalSlash },
   help: { filled: FaQuestionCircle, outline: FaQuestionCircleSlash },

--- a/react/src/Navigation/Tabs/Tabs.js
+++ b/react/src/Navigation/Tabs/Tabs.js
@@ -1,7 +1,56 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react';
+import TwixtLink from '../../CallsToAction/Link';
 
-function Tabs() {
-  return <>Tabs goes here.</>
-}
+const Tabs = ({ items, direction = "horizontal", defaultActiveTab = 0, tabType = "underline" }) => {
+  const [activeTab, setActiveTab] = useState(defaultActiveTab);
+
+  useEffect(() => {
+    setActiveTab(defaultActiveTab);
+  }, [defaultActiveTab]);
+
+  const renderIcon = (Icon) => {
+    return Icon ? <Icon className="shrink-0 size-4" /> : null;
+  };
+
+  return (
+    <div className={`tabs-component ${direction === 'vertical' ? 'flex flex-wrap' : ''}`}>
+      <div className={`${direction === 'vertical' ? 'border-e mr-2' : 'border-b'} border-gray-200 dark:border-neutral-700`}>
+        <nav
+          className={`flex ${direction === 'vertical' ? 'flex-col space-y-4 pr-2' : 'gap-x-4'} `}
+          aria-label="Tabs"
+          role="tablist"
+          aria-orientation={direction}
+        >
+          {items.map((item, index) => (
+            <TwixtLink
+              key={index}
+              label={item.label}
+              leftIcon={renderIcon(item.leftIcon)}
+              rightIcon={renderIcon(item.rightIcon)}
+              appendClass={`p-2 ${activeTab === index ? 'border-b border-b-blue-500' : ''}`}
+              onClick={(e) => {
+                e.preventDefault();
+                setActiveTab(index);
+              }}
+            />
+          ))}
+        </nav>
+      </div>
+      <div className="mt-3">
+        {items.map((item, index) => (
+          <div
+            key={index}
+            id={`tab-panel-${index}`}
+            role="tabpanel"
+            className={activeTab === index ? '' : 'hidden'}
+            aria-labelledby={`tab-item-${index}`}
+          >
+            <p className="text-gray-500 dark:text-neutral-400">{item.content}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
 
 export default Tabs


### PR DESCRIPTION
### Current Problem

No Tab Component

### After Implementation

1. Add support for vertical and horizontal
2. Add support for left / right icon
3. updated the missing autodocs

<img width="767" alt="image" src="https://github.com/user-attachments/assets/6ea5c52d-8f92-471a-aa9a-c053ee143409">

# Important Note

> Tab type need to be improved like card and half rounded background etc
